### PR TITLE
update drupalcorn camp to be year ambiguous

### DIFF
--- a/cornbot/test.cornbot.rb
+++ b/cornbot/test.cornbot.rb
@@ -143,7 +143,7 @@ class DrupalCorn
   def execute(m)
     m.reply "DrupalCorn Camp is a Drupal Camp, held each year somewhere in the state of Iowa."
     m.reply "Latest camp:"
-    m.reply "http://2013.drupalcorn.org"
+    m.reply "http://drupalcorn.org"
   end
 end
 


### PR DESCRIPTION
drupalcorn.org should always redirect to the next camp when it's ready. This way we don't have to remember to update the URL here.
